### PR TITLE
Updates for new version of upload app (with new way of handling conf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,28 @@ Property | Value
 `sigsp.config.login-button-html`  |  Optional property used to provide custom html for the login button. Example: `sigsp.config.login-button-html=<a href='../secure/main' class='btn btn-primary'>Login</a>``server.port`  |  Set the server port for the service. If TLS is used (port 8443) then the TLS settings must also be settings
 `tomcat.ajp.enabled`  |  true or false dependeing on whether AJP should be exposed
 `spring.servlet.multipart.max-file-size`  |  Sets the max file upload size. This value can be set to a maximum of 10 MB. Sizes larger than 10MB requires other measures to increase internal Spring Boot limitations.
-`sigsp.config.signpage`  |  Sets properties related to the sign page
+~~`sigsp.config.signpage`~~  |  ~~Sets properties related to the sign page~~<br />Is now set as part of the SignService policy configuration under `signservice.config.pdf-signature-pages`. See [application.properties](resources/upload-sign-sp/application.properties).
 `sigsp.config.signpage.image.include-identifier-in-name`  |  A value of true includes the user ID in the user name. E.g. "John Doe (id-of-john-doe)" when included in a PDF sign image. A value of false excludes the uer ID from the displayed name.
-`signservice.pdf-signature-image.template`  |  Sets properties relatedto PDF sign image
-`sigsp.federation.metadata` | Properties for downloading, validating and caching SAML metadta
+~~`signservice.pdf-signature-image.template`~~  |  ~~Sets properties relatedto PDF sign image~~<br />Is now set as part of the SignService policy configuration under `signservice.config.pdf-signature-image-templates`. See [application.properties](resources/upload-sign-sp/application.properties).
+`sigsp.federation.metadata` | Properties for downloading, validating and caching SAML metadata
 `signservice.credential`  |  Properties for setting up the signing key for signing SignRequest to the signature service
-`signservice.config.default-sign-requester-id`  |  The EntityID of this application expressed as the sign requesting service in requests to the signing service.
-`signservice.config.sign-service-id`  |  The EntityID of the sign service  |
-`signservice.config.default-destination-url` |  The URL where the Sign Request to the sign service is sent.
-`signservice.config.compatible-pre-sign-service-id[n]` | zero or more identifiers of SP services compatible with this service in terms of SignPage usages. Only SP services listed here (own service are automatically included) are alloewd to have created the first signature for this service to accept to add another signature.
+~~`signservice.config.default-sign-requester-id`~~  |  ~~The EntityID of this application expressed as the sign requesting service in requests to the signing service.~~<br />Replaced by `sigsp.sp.entityid` (see below).
+`sigsp.sp.entityid` | The EntityID of this application expressed as the sign requesting service in requests to the signing service.
+`signservice.config.sign-service-id`<sup>*</sup>  |  The EntityID of the sign service  |
+`signservice.config.default-destination-url`<sup>*</sup> |  The URL where the Sign Request to the sign service is sent.
+`signservice.config.compatible-pre-sign-service-id[n]` | Zero or more identifiers of SP services compatible with this service in terms of SignPage usages. Only SP services listed here (own service are automatically included) are allowed to have created the first signature for this service to accept to add another signature.
+
+> \[*\]: Only required if not using the SignService Integration REST service (see below).
+
+The application can also be configured to use the SignService Integration REST service for SignService integration. In the future, this will be the only option, but for now this is experimental. To turn on REST client support the following settings are essential:
+
+Property | Valie
+--- | ---
+`signservice.rest.enabled` | Whether REST client support is enabled or not (default is `false`).
+`signservice.rest.server-url` | The URL to the SignService Integration REST service.
+`signservice.rest.client-username` | The username for the REST client (when authenticating to the REST service).
+`signservice.rest.client-password` | The password for the REST client (when authenticating to the REST service).
+`signservice.default-policy-name` | The name of the SignService integration policy to use (must be configured by REST server).
 
 
 ## 3. Running the docker container

--- a/resources/upload-sign-sp/application.properties
+++ b/resources/upload-sign-sp/application.properties
@@ -30,26 +30,14 @@ tomcat.ajp.port=8009
 tomcat.ajp.remoteauthentication=false
 tomcat.ajp.enabled=true
 
-# Sign page configuration
-sigsp.config.signpage.location=file://${sigsp.config.dataDir}signimage/eduSign-page.pdf
-sigsp.config.signpage.x=37
-sigsp.config.signpage.y=165
-sigsp.config.signpage.cols=2
-sigsp.config.signpage.rows=6
-sigsp.config.signpage.xIncr=268
-sigsp.config.signpage.yincr=105
-sigsp.config.signpage.image.template=eduSign-image
-sigsp.config.signpage.image.scale=-74
-sigsp.config.signpage.image.include-identifier-in-name=false
+# REST client configuration
+signservice.rest.enabled=false
+signservice.rest.server-url=https://sig.sunet.se/signint
+signservice.rest.client-username=upload-app
+signservice.rest.client-password=change-me
 
-# Test signature image templates
-signservice.pdf-signature-image.template[0].resource=file://${sigsp.config.dataDir}signimage/eduSign-image.svg
-signservice.pdf-signature-image.template[0].reference=eduSign-image
-signservice.pdf-signature-image.template[0].width=967
-signservice.pdf-signature-image.template[0].height=351
-signservice.pdf-signature-image.template[0].includeSignerName=true
-signservice.pdf-signature-image.template[0].includeSigningTime=true
-signservice.pdf-signature-image.template[0].fields.idp=IdP EntityID
+# Sign page configuration
+sigsp.config.signpage.image.include-identifier-in-name=false
 
 #
 # Metadata
@@ -57,6 +45,14 @@ signservice.pdf-signature-image.template[0].fields.idp=IdP EntityID
 sigsp.federation.metadata.url=https://mds.swamid.se/md/swamid-idp.xml
 sigsp.federation.metadata.validation-certificate=file://${sigsp.config.dataDir}metadata/md-signer2.crt
 sigsp.federation.metadata.backup-dir=${sigsp.config.dataDir}metadata
+
+#
+# SAML SP name
+#
+sigsp.sp.entityid=https://sig.sunet.se/sig-sp
+
+# Whether we support the SignMessage extension
+signservice.sign-message.enabled=false
 
 #
 # Credentials
@@ -70,8 +66,10 @@ signservice.credential.key-password=Test1234
 #
 # Policy configuration
 #
-signservice.config.policy=default
-signservice.config.default-sign-requester-id=https://sig.sunet.se/sig-sp
+signservice.default-policy-name=edusign
+
+signservice.config.policy=${signservice.default-policy-name}
+signservice.config.default-sign-requester-id=${sigsp.sp.entityid}
 signservice.config.default-signature-algorithm=http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
 signservice.config.sign-service-id=https://sig.sunet.se/signservice
 signservice.config.default-destination-url=https://sig.idsec.se/sigservice-dev/request
@@ -80,6 +78,27 @@ signservice.config.sign-service-certificates[0]=file://${sigsp.config.dataDir}ke
 signservice.config.trust-anchors[0]=file://${sigsp.config.dataDir}keystore/sunet-dev-ca.crt
 
 signservice.config.default-authn-context-ref=urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+
+signservice.config.pdf-signature-image-templates[0].reference=eduSign-image
+signservice.config.pdf-signature-image-templates[0].svg-image-file.resource=file://${sigsp.config.dataDir}signimage/eduSign-image.svg
+signservice.config.pdf-signature-image-templates[0].svg-image-file.eagerly-load-contents=true
+signservice.config.pdf-signature-image-templates[0].width=967
+signservice.config.pdf-signature-image-templates[0].height=351
+signservice.config.pdf-signature-image-templates[0].includeSignerName=true
+signservice.config.pdf-signature-image-templates[0].includeSigningTime=true
+signservice.config.pdf-signature-image-templates[0].fields.idp=IdP EntityID
+
+signservice.config.pdf-signature-pages[0].id=edusign-sign-page
+signservice.config.pdf-signature-pages[0].pdf-document.resource=file://${sigsp.config.dataDir}signimage/eduSign-page.pdf
+signservice.config.pdf-signature-pages[0].pdf-document.eagerly-load-contents=true
+signservice.config.pdf-signature-pages[0].rows=6
+signservice.config.pdf-signature-pages[0].columns=2
+signservice.config.pdf-signature-pages[0].signature-image-reference=eduSign-image
+signservice.config.pdf-signature-pages[0].image-placement-configuration.x-position=37
+signservice.config.pdf-signature-pages[0].image-placement-configuration.y-position=165
+signservice.config.pdf-signature-pages[0].image-placement-configuration.x-increment=268
+signservice.config.pdf-signature-pages[0].image-placement-configuration.y-increment=105
+signservice.config.pdf-signature-pages[0].image-placement-configuration.scale=-74
 
 signservice.config.default-certificate-requirements.certificateType=PKC
 signservice.config.default-certificate-requirements.attribute-mappings[0].sources[0].name=urn:oid:1.3.6.1.4.1.5923.1.1.1.6
@@ -120,7 +139,7 @@ signservice.config.default-certificate-requirements.attribute-mappings[5].destin
 signservice.config.default-certificate-requirements.attribute-mappings[5].destination.friendly-name=eduPersonAssurance
 signservice.config.default-certificate-requirements.attribute-mappings[5].destination.required=false
 
-signservice.config.stateless=false
+signservice.config.stateless=true
 
 # Response processing
 signservice.response.config.strict-processing=false


### PR DESCRIPTION
Inför nästa release av upload-appen så behöver vissa saker konfas på ett annorlunda sätt. README är uppdaterad samt en ny application.properties finns i resources. Tror inte att Leif konfar något kring de saker som ändrats så att det ska i princip räcka med att den nya application.properties används. Men kolla för säkerhets skull.

Jag har också förberett så att upload-appen kan konfas att använda REST-servicen istället för att göra allt själv. Fördelen med detta vore att vi bara skulle ha signservice konfig på ett ställe. Men detta blir senare eftersom REST-tjänsten än så länge bara finns i test (där den funkar bra med upload-appen).

